### PR TITLE
Old = New Fix

### DIFF
--- a/appdaemon/threading.py
+++ b/appdaemon/threading.py
@@ -483,7 +483,7 @@ class Threading:
                 else:
                     new = None
 
-            if (cold is None or cold == old) and (cnew is None or cnew == new):
+            if (cold is None or cold == old) and (cnew is None or cnew == new) and new != old:
                 if "duration" in kwargs:
                     # Set a timer
                     exec_time = await self.AD.sched.get_now() + timedelta(seconds=int(kwargs["duration"]))
@@ -511,7 +511,7 @@ class Threading:
                         "kwargs": kwargs
                     })
             else:
-                if "__duration" in kwargs:
+                if "__duration" in kwargs and new != old:
                     # cancel timer
                     await self.AD.sched.cancel_timer(name, kwargs["__duration"])
 


### PR DESCRIPTION
This will fix the issue of AD executing callbacks, even when old is equal to new. So with this, old must not be equal to new before firing