### PR TITLE
Fix for when broker connects with service call

### DIFF
--- a/appdaemon/plugins/mqtt/mqttplugin.py
+++ b/appdaemon/plugins/mqtt/mqttplugin.py
@@ -218,7 +218,7 @@ class MqttPlugin(PluginBase):
     async def call_plugin_service(self, namespace, domain, service, kwargs):
 
         if 'topic' in kwargs:
-            if not self.initialized:  # ensure mqtt plugin is connected
+            if not self.mqtt_connected:  # ensure mqtt plugin is connected
                 self.logger.warning("Attempt to call Mqtt Service while disconnected: %s", service)
                 return None
             try:


### PR DESCRIPTION
Fix for when the plugin disconnects from Broker and reconnects, so there is no race condition