### PR TITLE
Allow to use standard event callback

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -24,6 +24,7 @@ Change Log
 - Admin UI now breaks out App instance and lifetime callback stats separately
 - Convert admin and dashboard to get_state from stream
 - Increase default work factor for password hashes to 12
+- Allow to get all events using standard callback, by specifing the `global_callback` switch
 
 **Fixes**
 


### PR DESCRIPTION
This allows to use standard event callback for logs event, so it can be picked up using standard callbacks
This is good as it helps  to get all events data using a single callback